### PR TITLE
Rename getStatus() and getStatusDuration() methods to getState() and getStateDuration(), respectively

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -789,7 +789,7 @@ An enumeration listing the different high-level states that a contact can have.
 
 * `ContactStateType.INCOMING`: Indicates that the contact is incoming and is waiting for acceptance.  This state is skipped for `ContactType.VOICE` contacts but is essential for `ContactType.QUEUE_CALLBACK` contacts.
 * `ContactStateType.CONNECTING`: Indicates that the contact is currently connecting.  For `ContactType.VOICE` contacts, this is when the user will accept the incoming call.  For all other types, the contact will be accepted during the `ContactStateType.INCOMING` state.
-*
+
 ### `ConnectionStateType`
 An enumeration listing the different states that a connection can have.
 

--- a/src/api.js
+++ b/src/api.js
@@ -496,13 +496,17 @@
       return this._getData().type;
    };
 
-   Contact.prototype.getStatus = function() {
+   Contact.prototype.getState = function() {
       return this._getData().state;
    };
 
-   Contact.prototype.getStatusDuration = function() {
+   Contact.prototype.getStatus = Contact.prototype.getState;
+
+   Contact.prototype.getStateDuration = function() {
       return connect.now() - this._getData().state.timestamp.getTime() + connect.core.getSkew();
    };
+
+   Contact.prototype.getStatusDuration = Contact.prototype.getStateDuration;
 
    Contact.prototype.getQueue = function() {
       return this._getData().queue;
@@ -569,7 +573,7 @@
    };
 
    Contact.prototype.isConnected = function() {
-      return this.getStatus().type === connect.ContactStateType.CONNECTED;
+      return this.getState().type === connect.ContactStateType.CONNECTED;
    };
 
    Contact.prototype.accept = function(callbacks) {
@@ -628,7 +632,7 @@
       var client = connect.core.getClient();
       var connectionId = null;
       var holdingConn = connect.find(this.getConnections(), function(conn) {
-         return conn.getStatus().type === connect.ConnectionStateType.HOLD;
+         return conn.getState().type === connect.ConnectionStateType.HOLD;
       });
 
       if (holdingConn != null) {
@@ -722,13 +726,17 @@
 
    Connection.prototype.getAddress = Connection.prototype.getEndpoint;
 
-   Connection.prototype.getStatus = function() {
+   Connection.prototype.getState = function() {
       return this._getData().state;
    };
 
-   Connection.prototype.getStatusDuration = function() {
+   Connection.prototype.getStatus = Connection.prototype.getState;
+
+   Connection.prototype.getStateDuration = function() {
       return connect.now() - this._getData().state.timestamp.getTime() + connect.core.getSkew();
    };
+
+   Connection.prototype.getStatusDuration = Connection.prototype.getStateDuration;
 
    Connection.prototype.getType = function() {
       return this._getData().type;
@@ -739,19 +747,19 @@
    };
 
    Connection.prototype.isActive = function() {
-      return connect.contains(connect.CONNECTION_ACTIVE_STATES, this.getStatus().type);
+      return connect.contains(connect.CONNECTION_ACTIVE_STATES, this.getState().type);
    };
 
    Connection.prototype.isConnected = function() {
-      return this.getStatus().type === connect.ConnectionStateType.CONNECTED;
+      return this.getState().type === connect.ConnectionStateType.CONNECTED;
    };
 
    Connection.prototype.isConnecting = function() {
-      return this.getStatus().type === connect.ConnectionStateType.CONNECTING;
+      return this.getState().type === connect.ConnectionStateType.CONNECTING;
    };
 
    Connection.prototype.isOnHold = function() {
-      return this.getStatus().type === connect.ConnectionStateType.HOLD;
+      return this.getState().type === connect.ConnectionStateType.HOLD;
    };
 
    Connection.prototype.getSoftphoneMediaInfo = function() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -465,11 +465,11 @@ declare namespace connect {
         /**
          * Get a ContactState object representing the state of the contact.
          */
-        getStatus(): ContactState;
+        getState(): ContactState;
         /**
          * Get the duration of the contact state in milliseconds relative to local time.
          */
-        getStatusDuration(): number;
+        getStateDuration(): number;
         /**
          * Get the queue associated with the contact.
          */

--- a/src/ringtone.js
+++ b/src/ringtone.js
@@ -82,7 +82,7 @@
          contact.onEnded(lily.hitch(self, self._stopRingtone));
          // Just to make sure to stop the ringtone in case of the failures of specific callbacks(onAccepted,onConnected);
          contact.onRefresh(function(contact){
-          if(contact.getStatus().type !== connect.ContactStatusType.CONNECTING){
+          if(contact.getState().type !== connect.ContactStateType.CONNECTING){
             self._stopRingtone();
           }
          });
@@ -148,7 +148,7 @@
       });
 
       new connect.Agent().getContacts().forEach(function(contact){
-        if(contact.getStatus().type === connect.ContactStatusType.CONNECTING){
+        if(contact.getState().type === connect.ContactStateType.CONNECTING){
           onContactConnect(contact);
         }
       });

--- a/src/softphone.js
+++ b/src/softphone.js
@@ -74,9 +74,9 @@
         
 
         var isContactTerminated = function(contact) {
-            return contact.getStatus().type === connect.ContactStatusType.ENDED ||
-                   contact.getStatus().type === connect.ContactStatusType.ERROR ||
-                   contact.getStatus().type === connect.ContactStatusType.MISSED;
+            return contact.getState().type === connect.ContactStateType.ENDED ||
+                   contact.getState().type === connect.ContactStateType.ERROR ||
+                   contact.getState().type === connect.ContactStateType.MISSED;
         };
 
         var destroySession = function (agentConnectionId) {
@@ -124,8 +124,8 @@
                     destroySession(agentConnectionId);
                 }
                 if (contact.isSoftphoneCall() && !callsDetected[agentConnectionId] && (
-                        contact.getStatus().type === connect.ContactStatusType.CONNECTING ||
-                        contact.getStatus().type === connect.ContactStatusType.INCOMING)) {
+                        contact.getState().type === connect.ContactStateType.CONNECTING ||
+                        contact.getState().type === connect.ContactStateType.INCOMING)) {
 
                     // Set to true, this will block subsequent invokes from entering.
                     callsDetected[agentConnectionId] = true;
@@ -134,7 +134,7 @@
                     // Ensure our session state matches our contact state to prevent issues should we lose track of a contact.
                     sanityCheckActiveSessions(rtcSessions);
 
-                    if (contact.getStatus().type === connect.ContactStatusType.CONNECTING) {
+                    if (contact.getState().type === connect.ContactStateType.CONNECTING) {
                         publishTelemetryEvent("Softphone Connecting", contact.getContactId());
                     }
 

--- a/test/unit/softphone.spec.js
+++ b/test/unit/softphone.spec.js
@@ -17,7 +17,7 @@ describe('SoftphoneManager', function () {
             sinon.stub(contact, "isSoftphoneCall").returns(true);
             sinon.stub(contact, "isInbound").returns(true);
             sinon.stub(contact, "getStatus").returns({
-                type: connect.ContactStatusType.CONNECTING
+                type: connect.ContactStateType.CONNECTING
             });
             sinon.stub(connect, 'RTCSession').returns({});
 
@@ -55,7 +55,7 @@ describe('SoftphoneManager', function () {
         it('RTC session will not be created for the contact which is already connected with one RTC session', function () {
             contact.getStatus.restore();
             sinon.stub(contact, "getStatus").returns({
-                type: connect.ContactStatusType.CONNECTED
+                type: connect.ContactStateType.CONNECTED
             });
             connect.RTCsession = sinon.spy();
             var softphoneManager = new connect.SoftphoneManager({});

--- a/test/unit/softphone.spec.js
+++ b/test/unit/softphone.spec.js
@@ -4,10 +4,7 @@ describe('SoftphoneManager', function () {
     describe('#SoftphoneManager RTC session', function () {
         var bus,
             contact,
-            agent,
-            status,
-            contactId,
-            RTCsession;
+            contactId;
 
         before(function () {
             bus = connect.core.getEventBus(),
@@ -16,7 +13,7 @@ describe('SoftphoneManager', function () {
 
             sinon.stub(contact, "isSoftphoneCall").returns(true);
             sinon.stub(contact, "isInbound").returns(true);
-            sinon.stub(contact, "getStatus").returns({
+            sinon.stub(contact, "getState").returns({
                 type: connect.ContactStateType.CONNECTING
             });
             sinon.stub(connect, 'RTCSession').returns({});
@@ -37,7 +34,7 @@ describe('SoftphoneManager', function () {
             contact.isSoftphoneCall.restore();
             contact.isInbound.restore();
             contact.getAgentConnection.restore();
-            contact.getStatus.restore();
+            contact.getState.restore();
             connect.isOperaBrowser.restore();
             connect.getOperaBrowserVersion.restore();
             connect.RTCSession.restore();
@@ -45,7 +42,7 @@ describe('SoftphoneManager', function () {
             connect.Agent.prototype.getContacts();
         });
 
-        it('RTC session created for a incomming contact', function () {
+        it('RTC session created for an incoming contact', function () {
             var softphoneManager = new connect.SoftphoneManager({});
             bus.trigger(connect.ContactEvents.INIT, contact);
             bus.trigger(connect.core.getContactEventName(connect.ContactEvents.REFRESH, contactId), contact);
@@ -53,8 +50,8 @@ describe('SoftphoneManager', function () {
         });
 
         it('RTC session will not be created for the contact which is already connected with one RTC session', function () {
-            contact.getStatus.restore();
-            sinon.stub(contact, "getStatus").returns({
+            contact.getState.restore();
+            sinon.stub(contact, "getState").returns({
                 type: connect.ContactStateType.CONNECTED
             });
             connect.RTCsession = sinon.spy();
@@ -75,7 +72,4 @@ describe('SoftphoneManager', function () {
             it('Multiple RTC session should not be created in case of voice system failures!')
         });
     });
-
-    
-
 });


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-connect-streams/issues/37

*Description of changes:*

- Renamed getStatus() and getStatusDuration() methods to getState() and getStateDuration(), respectively, so that it matches the methods as shown in the documentation (for both the `Contact` and `Connection` classes).
- The methods can still be called using the old naming convention for backwards compatibility. This is equivalent to how `agent.getStatus()` and `agent.getState()` reference the same method.
- Use the `ContactStateType` enum internally, as opposed to `ContactStatusType`
- Updated the type definition file to match the new method names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
