### PR TITLE
Typo fix: inital -> initial,  succesfully -> successfully in Documentation.md, src/index.d.ts

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -157,7 +157,7 @@ longer exist.  Users can also manually unsubscribe from events by calling
 connect.agent(function(agent) { ... });
 ```
 Subscribe a method to be called when the agent is initialized.  If the agent has
-already been initalized, the call is synchronous and the callback is invoked
+already been initialized, the call is synchronous and the callback is invoked
 immediately.  Otherwise, the callback is invoked once the first agent data is
 received from upstream.  This callback is provided with an `Agent` API object,
 which can also be created at any time after initialization is complete via `new
@@ -499,7 +499,7 @@ Get the initial connection of the contact.
 ```
 var initialConn = contact.getActiveInitialConnection();
 ```
-Get the inital connection of the contact, or null if the initial connection is
+Get the initial connection of the contact, or null if the initial connection is
 no longer active.
 
 ### `contact.getThirdPartyConnections()`

--- a/Documentation.md
+++ b/Documentation.md
@@ -392,7 +392,7 @@ Sets the agent localmedia to unmute mode.
 agent.onMuteToggle(function(obj) { //obj.muted provides the current status of the agent });
 ```
 Subscribe a method to be called when the agent updates the mute status, meaning
-that agents mute/unmute APIs are called and the local media stream is succesfully updated with the new status. 
+that agents mute/unmute APIs are called and the local media stream is successfully updated with the new status. 
 
 ## Contact API
 The Contact API provides event subscription methods and action methods which can be called on behalf of a specific

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -515,7 +515,7 @@ declare namespace connect {
          */
         getInitialConnection(): Connection;
         /**
-         * Get the inital connection of the contact, or null if the initial connection
+         * Get the initial connection of the contact, or null if the initial connection
          * is no longer active.
          */
         getActiveInitialConnection(): Connection;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -284,7 +284,7 @@ declare namespace connect {
         /**
          * Subscribe a method to be called when the agent updates the mute status,
          * meaning that agents mute/unmute APIs are called and the local media stream
-         * is succesfully updated with the new status.
+         * is successfully updated with the new status.
          *
          * @param callback A callback to receive updates on agent mute state
          */


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
I fix typo. 
`inital` ->` initial`
`succesfully` -> `successfully`
in Documentation.md, src/index.d.ts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.