### PR TITLE
Add an option to force the login popup into a window.

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -88,13 +88,14 @@ everything set up correctly and that you are able to listen for events.
 ### `connect.core.initCCP()`
 ```
 connect.core.initCCP(containerDiv, {
-   ccpUrl:        ccpUrl,        /*REQUIRED*/
-   loginPopup:    true,          /*optional, default TRUE*/
-   loginUrl:      loginUrl,      /*optional*/
-   region: region                /*REQUIRED*/
-   softphone:     {              /*optional*/
-      disableRingtone:  true,    /*optional*/
-      ringtoneUrl: ringtoneUrl   /*optional*/
+   ccpUrl:                 ccpUrl,        /*REQUIRED*/
+   loginPopup:             true,          /*optional, default TRUE*/
+   loginPopupForceWindow:  false,          /*optional, default FALSE*/
+   loginUrl:               loginUrl,      /*optional*/
+   region:                 region         /*REQUIRED*/
+   softphone:     {                       /*optional*/
+      disableRingtone:     true,          /*optional*/
+      ringtoneUrl:         ringtoneUrl    /*optional*/
    }
 });
 ```
@@ -108,6 +109,10 @@ and made available to your JS client code.
 * `region`: Amazon connect instance region. ex: us-west-2 for PDX ccp instance.  only required for chat channel.
 * `loginPopup`: Optional, defaults to `true`.  Set to `false` to disable the login
   popup which is shown when the user's authentication expires.
+  `loginPopupForceWindow`: Optional, defaults to `false`. Set to `true` to force
+  the login popup to open in a centered pop-up window. When `false`, the popup will
+  behave according to the user's browser settings, which often defaults to opening 
+  in a new tab.
 * `loginUrl`: Optional.  Allows custom URL to be used to initiate the ccp, as in
   the case of SAML authentication.
 * `softphone`: This object is optional and allows you to specify some settings

--- a/Documentation.md
+++ b/Documentation.md
@@ -89,8 +89,12 @@ everything set up correctly and that you are able to listen for events.
 ```
 connect.core.initCCP(containerDiv, {
    ccpUrl:                 ccpUrl,        /*REQUIRED*/
-   loginPopup:             true,          /*optional, default TRUE*/
-   loginPopupForceWindow:  false,          /*optional, default FALSE*/
+   loginPopup:             {              /*optional, default TRUE*/
+      autoClose:           ture,          /*optional, default FALSE*/
+      forceWindow:         true,          /*optional, default FALSE*/
+      height:              600,           /*optional*/
+      width:               400,           /*optional*/
+   },
    loginUrl:               loginUrl,      /*optional*/
    region:                 region         /*REQUIRED*/
    softphone:     {                       /*optional*/
@@ -106,13 +110,23 @@ and made available to your JS client code.
 * `ccpUrl`: The URL of the CCP.  This is the page you would normally navigate to
   in order to use the CCP in a standalone page, it is different for each
   instance.
-* `region`: Amazon connect instance region. ex: us-west-2 for PDX ccp instance.  only required for chat channel.
-* `loginPopup`: Optional, defaults to `true`.  Set to `false` to disable the login
-  popup which is shown when the user's authentication expires.
-  `loginPopupForceWindow`: Optional, defaults to `false`. Set to `true` to force
-  the login popup to open in a centered pop-up window. When `false`, the popup will
-  behave according to the user's browser settings, which often defaults to opening 
-  in a new tab.
+* `region`: Amazon connect instance region. ex: us-west-2 for PDX ccp instance. 
+   Only required for chat channel.
+* `loginPopup`: Optional.  Set to `false` to disable the login popup which is 
+   shown when the user's authentication expires. Provide an object with the 
+   following options to provide settings for this window:
+   * `autoClose`: Optional, defaults to `false`. Set to `true` to automatically
+      close the login popup after the user logs in.
+   * `forceWindow`: Optional, defaults to `false`. Set to `true` to force the 
+      login popup to open in a centered pop-up window. When `false`, the popup 
+      will behave according to the user's browser settings, which often defaults 
+      to opening in a new tab.
+   * `height`: Optional, only valid when `forceWindow` is set to `true`. This 
+      allows you to define the height of the login pop-up window if you do not 
+      like the default.
+   * `width`: Optional, only valid when `forceWindow` is set to `true`. This 
+      allows you to define the width of the login pop-up window if you do not 
+      like the default.
 * `loginUrl`: Optional.  Allows custom URL to be used to initiate the ccp, as in
   the case of SAML authentication.
 * `softphone`: This object is optional and allows you to specify some settings

--- a/src/core.js
+++ b/src/core.js
@@ -493,7 +493,7 @@
         try {
           var loginUrl = createLoginUrl(params);
           connect.getLog().warn("ACK_TIMEOUT occurred, attempting to pop the login page if not already open.");
-          connect.core.loginWindow = connect.core.getPopupManager().open(loginUrl, connect.MasterTopics.LOGIN_POPUP);
+          connect.core.loginWindow = connect.core.getPopupManager().open(loginUrl, connect.MasterTopics.LOGIN_POPUP, params.loginPopupForceWindow);
 
         } catch (e) {
           connect.getLog().error("ACK_TIMEOUT occurred but we are unable to open the login popup.").withException(e);

--- a/src/core.js
+++ b/src/core.js
@@ -493,8 +493,9 @@
         try {
           var loginUrl = createLoginUrl(params);
           connect.getLog().warn("ACK_TIMEOUT occurred, attempting to pop the login page if not already open.");
-          connect.core.loginWindow = connect.core.getPopupManager().open(loginUrl, connect.MasterTopics.LOGIN_POPUP, params.loginPopupForceWindow);
-
+          debugger;
+          var options = params.loginPopup && params.loginPopup.forceWindow ? params.loginPopup : {}
+          connect.core.loginWindow = connect.core.getPopupManager().open(loginUrl, connect.MasterTopics.LOGIN_POPUP, options);
         } catch (e) {
           connect.getLog().error("ACK_TIMEOUT occurred but we are unable to open the login popup.").withException(e);
         }
@@ -510,7 +511,7 @@
           global.clearInterval(connect.core.iframeRefreshInterval);
           connect.core.iframeRefreshInterval = null;
           connect.core.getPopupManager().clear(connect.MasterTopics.LOGIN_POPUP);
-          if (params.loginPopupAutoClose && connect.core.loginWindow) {
+          if (params.loginPopup && params.loginPopup.autoClose && connect.core.loginWindow) {
             connect.core.loginWindow.close();
             connect.core.loginWindow = null;
           }

--- a/src/core.js
+++ b/src/core.js
@@ -493,7 +493,6 @@
         try {
           var loginUrl = createLoginUrl(params);
           connect.getLog().warn("ACK_TIMEOUT occurred, attempting to pop the login page if not already open.");
-          debugger;
           var options = params.loginPopup && params.loginPopup.forceWindow ? params.loginPopup : {}
           connect.core.loginWindow = connect.core.getPopupManager().open(loginUrl, connect.MasterTopics.LOGIN_POPUP, options);
         } catch (e) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,25 @@ declare namespace connect {
     ringtoneUrl?: string;
   }
 
+  interface LoginOptions {
+    /*
+    * Whether to auto close the login prompt.
+    */
+    autoClose?: boolean,
+    /*
+    * Whether to force to login prompt into a new window.
+    */
+    forceWindow?: boolean,
+    /* 
+    * The height of the login prompt window.
+    */
+    height?: number,
+    /* 
+    * The width of the login prompt window.
+    */
+    width?: number,
+  }
+
   interface InitCCPOptions {
     /*
     * The URL for the Connect CCP.
@@ -94,11 +113,7 @@ declare namespace connect {
     /*
     * Whether to display the login view.
     */
-    loginPopup?: boolean;
-    /*
-    * Whether to auto-close the CCP popup window.
-    */
-    loginPopupAutoClose?: boolean;
+    loginPopup?: boolean | LoginOptions;
     /*
     * Options specifying softphone configuration.
     */

--- a/src/util.js
+++ b/src/util.js
@@ -406,31 +406,32 @@
    */
   connect.PopupManager = function () { };
 
-  connect.PopupManager.prototype.open = function(url, name, forceWindow) {
+  connect.PopupManager.prototype.open = function (url, name, options) {
     var then = this._getLastOpenedTimestamp(name);
     var now = new Date().getTime();
-    var win = null;      
+    var win = null;
     if (now - then > ONE_DAY_MILLIS) {
-      if (forceWindow === true) {
-        const height = 573;
-        const width = 400;
-        const y = window.top.outerHeight / 2 + window.top.screenY - (height / 2);
-        const x = window.top.outerWidth / 2 + window.top.screenX - (width / 2);
-        win = window.open('', name, `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=${width}, height=${height}, top=${y}, left=${x}`);
+      if (options && options.forceWindow === true) {
+        // default values below are chosen to provide a minimum height without scrolling
+        // and a unform margin based on the css of the ccp login page
+        var height = options.height ? options.height : 578;
+        var width = options.width ? options.width : 433;
+        var y = window.top.outerHeight / 2 + window.top.screenY - (height / 2);
+        var x = window.top.outerWidth / 2 + window.top.screenX - (width / 2);
+        win = window.open('', name, "width="+width+", height="+height+", top="+y+", left="+x);
         if (win.location !== url) {
-          win = window.open(url, name, `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=${width}, height=${height}, top=${y}, left=${x}`);
+          win = window.open(url, name, "width="+width+", height="+height+", top="+y+", left="+x);
         }
-       } else {
+      } else {
         win = window.open('', name);
         if (win.location !== url) {
           win = window.open(url, name);
         }
       }
-        this._setLastOpenedTimestamp(name, now);
-        
+      this._setLastOpenedTimestamp(name, now);
     }
     return win;
- };
+  };
 
   connect.PopupManager.prototype.clear = function (name) {
     var key = this._getLocalStorageKey(name);

--- a/src/util.js
+++ b/src/util.js
@@ -406,16 +406,28 @@
    */
   connect.PopupManager = function () { };
 
-  connect.PopupManager.prototype.open = function(url, name) {
+  connect.PopupManager.prototype.open = function(url, name, forceWindow) {
     var then = this._getLastOpenedTimestamp(name);
     var now = new Date().getTime();
     var win = null;      
     if (now - then > ONE_DAY_MILLIS) {
-       win = window.open('', name);
-       if (win.location !== url) {
+      if (forceWindow === true) {
+        const height = 573;
+        const width = 400;
+        const y = window.top.outerHeight / 2 + window.top.screenY - (height / 2);
+        const x = window.top.outerWidth / 2 + window.top.screenX - (width / 2);
+        win = window.open('', name, `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=${width}, height=${height}, top=${y}, left=${x}`);
+        if (win.location !== url) {
+          win = window.open(url, name, `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width=${width}, height=${height}, top=${y}, left=${x}`);
+        }
+       } else {
+        win = window.open('', name);
+        if (win.location !== url) {
           win = window.open(url, name);
-       }
-       this._setLastOpenedTimestamp(name, now);
+        }
+      }
+        this._setLastOpenedTimestamp(name, now);
+        
     }
     return win;
  };


### PR DESCRIPTION
This PR adds an initialization parameter that will force the login popup to open in a new window instead of using the browser settings, which often default to a new tab. A new tab for a login page is a pretty atypical UX, so an option to have it pop up into a window instead would be nice. 

Details:
When calling `window.open()`, if you provide a defined height and width, it will force the pop up into a window instead of a tab. I created a param for this called `loginPopuForceWindow` which defaults to false, preserving current behavior.

Personally, I would have turned `loginPopup` into an object and had the various related settings (like `loginPopupAutoClose`) embedded in it, but that didn't match the pattern you seemed to be going with and would have been a breaking change. Happy to make that change though if it is desirable.

