### PR TITLE
Updates to README, Documentation, and cheat-sheet for ChatJS and AWS SDK

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -82,7 +82,7 @@ $ npm run test
 ```
 
 ### Using the AWS SDK and Streams
-Streams has a "baked-in" version of the AWS-SDK in the `./src/aws-client.js` file. Make sure that you import Streams before the AWS SDK so that the AWS object bound to the Window is the object from your manually included SDK, and not from Streams.
+Streams has a "baked-in" version of the AWS-SDK in the `./src/aws-client.js` file. Make sure that you import Streams before the AWS SDK so that the `AWS` object bound to the `Window` is the object from your manually included SDK, and not from Streams.
 
 ## Initialization
 Initializing the Streams API is the first step to verify that you have

--- a/Documentation.md
+++ b/Documentation.md
@@ -81,6 +81,9 @@ To run unit tests:
 $ npm run test
 ```
 
+### Using the AWS SDK and Streams
+Streams has a "baked-in" version of the AWS-SDK in the `./src/aws-client.js` file. Make sure that you import Streams before the AWS SDK so that the AWS object bound to the Window is the object from your manually included SDK, and not from Streams.
+
 ## Initialization
 Initializing the Streams API is the first step to verify that you have
 everything set up correctly and that you are able to listen for events.
@@ -141,6 +144,12 @@ this:
   CCP is reduced to 400px tall.
 * CSS styles you add to your site will NOT be applied to the CCP because it is
   rendered in an iframe.
+* If you are trying to use chat specific functionalities, please also include
+  [ChatJS](https://github.com/amazon-connect/amazon-connect-chatjs) in your code.
+  We omit ChatJS from the Makefile so that streams can be used without ChatJS. 
+  Streams only needs ChatJS when it is being used for chat. Note that when including ChatJS,
+  it must be imported after StreamsJS, or there will be AWS SDK issues 
+  (ChatJS relies on the ConnectParticipant Service, which is not in the Streams AWS SDK).
 
 ### Event Subscription
 Event subscriptions link your app into the heartbeat of Amazon Connect by allowing your

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ npm run test
 ```
 
 ### Using the AWS SDK and Streams
-Streams has a "baked-in" version of the AWS-SDK in the `./src/aws-client.js` file. Make sure that you import Streams before the AWS SDK so that the AWS object bound to the Window is the object from your manually included SDK, and not from Streams.
+Streams has a "baked-in" version of the AWS-SDK in the `./src/aws-client.js` file. Make sure that you import Streams before the AWS SDK so that the `AWS` object bound to the `Window` is the object from your manually included SDK, and not from Streams.
 
 ## Initialization
 Initializing the Streams API is the first step to verify that you have

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ embed the Contact Control Panel (CCP) UI components into your page, and/or
 handle agent and contact state events directly giving you the power to control
 agent and contact state through an object oriented event driven interface.  You
 can use the built in interface or build your own from scratch: Streams gives you
-the choice.
+the choice. This library must be used in conjunction with [amazon-connect-chatjs](https://github.com/amazon-connect/amazon-connect-chatjs)
+in order to utilize Amazon Connect's Chat functionality.
 
 # Learn More
 To learn more about Amazon Connect and its capabilities, please check out
@@ -85,6 +86,10 @@ To run unit tests specifically:
 ```
 $ npm run test
 ```
+
+### Using the AWS SDK and Streams
+Streams has a "baked-in" version of the AWS-SDK in the `./src/aws-client.js` file. Make sure that you import Streams before the AWS SDK so that the AWS object bound to the Window is the object from your manually included SDK, and not from Streams.
+
 ## Initialization
 Initializing the Streams API is the first step to verify that you have
 everything setup correctly and that you will be able to listen for events.
@@ -143,7 +148,13 @@ this:
   CCP is reduced to 400px tall.
 * CSS styles you add to your site will NOT be applied to the CCP because it is
   rendered in an iframe.
-* If you are trying to use chat specific functionalities, please also include [ChatJs](https://github.com/amazon-connect/amazon-connect-chatjs) in your code. We omit ChatJs from the Makefile so that streams can be used without ChatJS. Streams only needs ChatJS when it is being used for chat.
+* If you are trying to use chat specific functionalities, please also include
+  [ChatJS](https://github.com/amazon-connect/amazon-connect-chatjs) in your code.
+  We omit ChatJS from the Makefile so that streams can be used without ChatJS. 
+  Streams only needs ChatJS when it is being used for chat. Note that when including ChatJS,
+  it must be imported after StreamsJS, or there will be AWS SDK issues 
+  (ChatJS relies on the ConnectParticipant Service, which is not in the Streams AWS SDK).
+
 ## Where to go from here
 Check out the full documentation [here](Documentation.md) to read more about
 subscribing to events and enacting state changes programmatically.

--- a/cheat-sheet.md
+++ b/cheat-sheet.md
@@ -230,7 +230,7 @@ Download agent logs
 	connect.getLog().download()
 
 
-Media Controller API for chat - ***New***
+Media Controller API for chat - ***New,ChatJS Required***
 
     connect.contact(function(contact){
     contact.getAgentConnections().forEach(function(connection){


### PR DESCRIPTION
*Issue #, if available:*
197
*Description of changes:*
Documentation docs now clearly indicate that ChatJS should be included for Chat functionality to work properly. They also mention the order in which the AWS SDK should be included in order to play well with Streams.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
