### PR TITLE
send iframe styling information to the embedded ccp

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -436,6 +436,18 @@
     // Build the upstream conduit communicating with the CCP iframe.
     var conduit = new connect.IFrameConduit(params.ccpUrl, window, iframe);
 
+    // Let CCP know if iframe is visible
+    iframe.onload = setTimeout(function() {
+      var style = window.getComputedStyle(iframe, null);
+      var data = {
+        display: style.display,
+        offsetWidth: iframe.offsetWidth,
+        offsetHeight: iframe.offsetHeight,
+        clientRectsLength: iframe.getClientRects().length
+      };
+      conduit.sendUpstream(connect.EventType.IFRAME_STYLE, data);
+    }, 10000);
+
     // Set the global upstream conduit for external use.
     connect.core.upstream = conduit;
 

--- a/src/event.js
+++ b/src/event.js
@@ -33,7 +33,8 @@
     'broadcast',
     'api_metric',
     'client_metric',
-    'mute'
+    'mute',
+    "iframe_style"
   ]);
 
   /**---------------------------------------------------------------


### PR DESCRIPTION
**Motivation**:
tracking custom ccp usage

**Testing**:
local embedded ccp

*Description of changes:*
use postMessage to send iframe styling information to ccp


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
