### PR TITLE
Normalized `getState()` / `getStatus()` methods

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -664,18 +664,18 @@ var type = contact.getType();
 ```
 Get the type of the contact. This indicates what type of media is carried over the connections of the contact.
 
-### `contact.getStatus()`
+###  `contact.getState()` / `contact.getStatus()`
 ```js
-var state = contact.getStatus();
+var state = contact.getState();
 ```
-Get a `ContactStatus` object representing the state of the contact. This object has the following fields:
+Get an object representing the state of the contact. This object has the following fields:
 
 * `type`: The contact state type, as per the `ContactStateType` enumeration.
 * `timestamp`: A `Date` object that indicates when the the contact was put in that state.
 
-### `contact.getStatusDuration()`
+### `contact.getStateDuration()` / `contact.getStatusDuration()`
 ```js
-var millis = contact.getStatusDuration();
+var millis = contact.getStateDuration();
 ```
 Get the duration of the contact state in milliseconds relative to local time. This takes into
 account time skew between the JS client and the Amazon Connect backend servers.
@@ -885,9 +885,9 @@ var endpoint = connection.getEndpoint();
 ```
 Gets the endpoint to which this connection is connected.
 
-### `connection.getStatus()`
+### `connection.getState()` / `connection.getStatus()`
 ```js
-var state = connection.getStatus();
+var state = connection.getState();
 ```
 Gets the `ConnectionState` object for this connection. This object has the
 following fields:
@@ -895,9 +895,9 @@ following fields:
 * `timestamp`: A `Date` object that indicates when the the connection was put in that state.
 * `type`: The connection state type, as per the `ConnectionStateType` enumeration.
 
-### `connection.getStatusDuration()`
+### `connection.getStateDuration()` / `connection.getStatusDuration()`
 ```js
-var millis = connection.getStatusDuration();
+var millis = connection.getStateDuration();
 ```
 Get the duration of the connection state, in milliseconds, relative to local time.
 This takes into account time skew between the JS client and the Amazon Connect service.

--- a/src/api.js
+++ b/src/api.js
@@ -530,13 +530,17 @@
     return this._getData().type;
   };
 
-  Contact.prototype.getStatus = function () {
+  Contact.prototype.getState = function () {
     return this._getData().state;
   };
 
-  Contact.prototype.getStatusDuration = function () {
+  Contact.prototype.getStatus = Contact.prototype.getState;
+
+  Contact.prototype.getStateDuration = function () {
     return connect.now() - this._getData().state.timestamp.getTime() + connect.core.getSkew();
   };
+
+  Contact.prototype.getStatusDuration = Contact.prototype.getStateDuration;
 
   Contact.prototype.getQueue = function () {
     return this._getData().queue;
@@ -768,13 +772,17 @@
 
   Connection.prototype.getAddress = Connection.prototype.getEndpoint;
 
-  Connection.prototype.getStatus = function () {
+  Connection.prototype.getState = function () {
     return this._getData().state;
   };
 
-  Connection.prototype.getStatusDuration = function () {
+  Connection.prototype.getStatus = Connection.prototype.getState;
+
+  Connection.prototype.getStateDuration = function () {
     return connect.now() - this._getData().state.timestamp.getTime() + connect.core.getSkew();
   };
+
+  Connection.prototype.getStatusDuration = Connection.prototype.getStateDuration;
 
   Connection.prototype.getType = function () {
     return this._getData().type;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -829,13 +829,19 @@ declare namespace connect {
      */
     getType(): ContactType;
 
-    /** Get a ContactState object representing the state of the contact. */
+    /** Get an object representing the state of the contact. */
+    getState(): ContactState;
+
+    /** Alias for `getStatus()` */
     getStatus(): ContactState;
 
     /**
      * Get the duration of the contact state in milliseconds relative to local time.
      * This takes into account time skew between the JS client and the Amazon Connect backend servers.
      */
+    getStateDuration(): number;
+
+    /** Alias for `getStateDuration()` */
     getStatusDuration(): number;
 
     /** Get the queue associated with the contact. */
@@ -1029,12 +1035,18 @@ declare namespace connect {
     getAddress(): Endpoint;
 
     /** Gets the `ConnectionState` object for this connection. */
+    getState(): ConnectionState;
+
+    /** Alias for `getState()` */
     getStatus(): ConnectionState;
 
     /**
      * Get the duration of the connection state, in milliseconds, relative to local time.
      * This takes into account time skew between the JS client and the Amazon Connect service.
      */
+    getStateDuration(): number;
+
+    /** Alias for `getStateDuration()` */
     getStatusDuration(): number;
 
     /** Get the type of connection. */


### PR DESCRIPTION
*Issue #, if available:* #37, #86

*Description of changes:*

Addressed #37 and #86 by ensuring all three
`Agent`, `Contact`, and `BaseConnection` have the following methods:

- `getState()`
- `getStateDuration()`
- `getStatus()`
- `getStatusDuration()`

It seems that some inconsistencies in the documentation initially
caused this confusion for customers. Given that `Agent` had already
aliased the methods, aliasing the methods for the other two APIs
seemed appropriate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
