### PR TITLE
Update hold documentation

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1155,6 +1155,8 @@ Put this connection on hold.
 
 Optional success and failure callbacks can be provided to determine if the operation was successful.
 
+During a conference call, you can't immediatly put all calls on hold due to the nature of Conferenced state in the VoiceService. We put one one leg on hold, wait for about 500ms and then put the other leg on hold.
+
 ### `connection.resume()`
 ```js
 conn.resume({

--- a/Documentation.md
+++ b/Documentation.md
@@ -1155,7 +1155,7 @@ Put this connection on hold.
 
 Optional success and failure callbacks can be provided to determine if the operation was successful.
 
-During a conference call, you can't immediatly put all calls on hold due to the nature of Conferenced state in the VoiceService. We put one one leg on hold, wait for about 500ms and then put the other leg on hold.
+During a conference call, you can't immediatly put all calls on hold due to the nature of Conferenced state in the VoiceService. We put one leg on hold, wait for about 500ms and then put the other leg on hold.
 
 ### `connection.resume()`
 ```js


### PR DESCRIPTION
I was running into issue while implementing holdAll functionality in an application that I'm working on. I found the following comment in the source code which explained what was causing the issue.
 
   /*
             * This is necessary due to the nature of Conferenced state
             * in the VoiceService.  We can't immediately put both legs
             * on hold or one of the calls will fail.  So we put one leg
             * on hold, wait ALL_HOLD_DELAY_TIMEOUT_MS milliseconds, then
             * put the other leg on hold.  This gives GACD Critical and
             * VoiceService enough time to update the conversation state
             * so that the second hold operation is valid.
             */

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
