### PR TITLE
Fixing inconsistent documentation of loginPopupAutoClose param

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -144,7 +144,7 @@ everything set up correctly and that you are able to listen for events.
         connect.core.initCCP(containerDiv, {
           ccpUrl: instanceURL,            // REQUIRED
           loginPopup: true,               // optional, defaults to `true`
-          loginPopupAutoClose: true,      // optional, defaults to `true`
+          loginPopupAutoClose: true,      // optional, defaults to `false`
           loginOptions: {                 // optional, if provided opens login in new window
             autoClose: true,              // optional, defaults to `false`
             height: 600,                  // optional, defaults to 578

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ everything setup correctly and that you will be able to listen for events.
         connect.core.initCCP(containerDiv, {
           ccpUrl: instanceURL,            // REQUIRED
           loginPopup: true,               // optional, defaults to `true`
-          loginPopupAutoClose: true,      // optional, defaults to `true`
+          loginPopupAutoClose: true,      // optional, defaults to `false`
           loginOptions: {                 // optional, if provided opens login in new window
             autoClose: true,              // optional, defaults to `false`
             height: 600,                  // optional, defaults to 578


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The docs are not consistent with respect to the default value of the `loginPopupAutoClose` parameter; the implementation of the parameter gives it a default value of false, but we need to fix a couple of places in the docs that say the default is true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

