### PR TITLE
Remove make as primary usage / build mechanism

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -237,7 +237,7 @@ this:
   rendered in an iframe.
 * If you are trying to use chat specific functionalities, please also include
   [ChatJS](https://github.com/amazon-connect/amazon-connect-chatjs) in your code.
-  We omit ChatJS from the Makefile so that streams can be used without ChatJS.
+  We omit ChatJS from the release file so that streams can be used without ChatJS.
   Streams only needs ChatJS when it is being used for chat. Note that when including ChatJS,
   it must be imported after StreamsJS, or there will be AWS SDK issues
   (ChatJS relies on the ConnectParticipant Service, which is not in the Streams AWS SDK).

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ To learn more about Amazon Connect and its capabilities, please check out
 the [Amazon Connect User Guide](https://docs.aws.amazon.com/connect/latest/userguide/).
 
 # Usage
-Run the Makefile to generate `amazon-connect-${version}.js`, then copy this file
-into your application or host it in an Amazon S3 bucket behind Amazon Cloudfront.
+amazon-connect-streams is available from [npmjs.com](https://www.npmjs.com/package/amazon-connect-streams). If you'd like to download it here, you can use either of the files like `release/connect-streams*`. 
 
-```
-$ make
-```
+Run `npm run release` to generate new release files. Full instructions for building locally with npm can be found [below](#build-your-own-with-npm). 
+
+We also support `make` for legacy builds.
 
 # Important Announcements
 1. December 2020 —  1.6.0 brings with it the release of a new Agent App API. In addition to the CCP, customers can now embed additional applications using connect.agentApp, including Customer Profiles and Wisdom (preview). See the [updated documentation](Documentation.md#initialization-for-ccp-customer-profiles-and-wisdom) for details on usage. We are also introducing a preview release for Amazon Connect Voice ID.


### PR DESCRIPTION
*Issue #, if available:*
#66 

*Description of changes:*
Update docs to mention the npm gulp scripts as the primary build method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

