### PR TITLE
Update InitCCPOptions with missing pageOptions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -300,6 +300,9 @@ declare namespace connect {
 
     /** Allows you to specify ringtone settings for Chat. */
     readonly chat?: ChatOptions;
+
+    /** Allows you to configure which configuration sections are displayed in the settings tab.  **/
+    readonly pageOptions?: PageOptions;
   }
 
 


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

* As per this commit : https://github.com/amazon-connect/amazon-connect-streams/commit/30d6452c3be216c8741cb9f7afb15d5950ad4d68 the documentation was updated to allow consumers to pass in an optional pageOptions.

* The typings were not updated. This commit updates the `src/index.d.ts` with the `pageOptions` for `InitCCPOptions`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

