### PR TITLE
Update README.md with corrected CCP URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ everything setup correctly and that you will be able to listen for events.
     <div id="container-div" style="width: 400px; height: 800px;"></div>
     <script type="text/javascript">
       var containerDiv = document.getElementById("container-div");
-      var instanceURL = "https://my-instance-domain.awsapps.com/connect/ccp-v2/";
+      var instanceURL = "https://my-instance-domain.my.connect.aws/ccp-v2/";
       // initialize the streams api
       function init() {
         // initialize the ccp


### PR DESCRIPTION
*Issue #, if available:*
Directly created a pull request, no Issue #

*Description of changes:*
In the "Initialization" section of README.md, the CCP URL is incorrect. 
> var instanceURL = “https://my-instance-domain.awsapps.com/connect/ccp-v2/“;

Users trying to initialize Amazon Connect Streams using the ".awsapps.com" domain will receive an "Access Error" (included below), and will be unable to log in to their instance.
> **Access Error**
> This application has not been enabled for your directory. Please contact your Administrator for more details.
![671EC790-52DA-4576-9045-377E28D8574F](https://user-images.githubusercontent.com/9167137/213539116-e7d9a1c0-cd00-4988-8305-854efa78d843.png)

**Solution:**
Include the correct CCP URL as defined by the Amazon Connect Administrator Guide [Provide access to the Contact Control Panel - Amazon Connect](https://docs.aws.amazon.com/connect/latest/adminguide/amazon-connect-contact-control-panel.html) 

Update the “**Initialization**” section in README.md with the following update.
> var instanceURL = “https://my-instance-domain.my.connect.aws/ccp-v2/“;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
