### PR TITLE
Allow configure iframe retry limit & retry delay through initccpparms

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -216,6 +216,8 @@ everything set up correctly and that you are able to listen for events.
           ccpAckTimeout: 5000, //optional, defaults to 3000 (ms)
           ccpSynTimeout: 3000, //optional, defaults to 1000 (ms)
           ccpLoadTimeout: 10000 //optional, defaults to 5000 (ms)
+          ccpIframeRefreshLimit: 1000, //optional, defaults to 6
+          ccpIframeRetryDelay: 1000 //optional, defaults to 2000 (ms)
          });
       }
     </script>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -419,6 +419,18 @@ declare namespace connect {
 
     /** A timeout in ms that indicates how long streams will wait for the initial ACKNOWLEDGE event from the shared worker while the CCP is still standing itself up. */
     readonly ccpLoadTimeout?: number;
+
+    /** 
+     * Allows you to configure iframe refresh limit
+     * @default 6
+     */
+    readonly ccpIframeRefreshLimit?: number;
+
+    /** 
+     * Allows you to configure iframe retry delay in ms
+     * @default 2000
+     */
+    readonly ccpIframeRetryDelay?: number;
   }
 
 
@@ -469,6 +481,18 @@ declare namespace connect {
 
     /** A timeout in ms that indicates how long streams will wait for the initial ACKNOWLEDGE event from the shared worker while the CCP is still standing itself up. */
     readonly ccpLoadTimeout?: number;
+
+    /** 
+     * Allows you to configure iframe refresh limit
+     * @default 6
+     */
+    readonly ccpIframeRefreshLimit?: number;
+
+    /** 
+     * Allows you to configure iframe retry delay in ms
+     * @default 2000
+     */
+    readonly ccpIframeRetryDelay?: number;
   }
 
   /** This enumeration lists the different types of agent states. */


### PR DESCRIPTION
Issue #, if available:
https://github.com/amazon-connect/amazon-connect-streams/issues/711#issue-1833629132

Description of changes:
When we call initCCP() we experienced that after 6 Iframe retry attempts, iframe failed to load. This is due to the CCP_IFRAME_REFRESH_LIMIT being set to 6 by default and there is no customisation through initCCPParams. We have a situation where we need to continue this retry process as many as we can.

This change adds the possibility to configure this limit via the initCCPParams object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
