### PR TITLE
Execute setupInitCCP on each re-execution of initCCP

### DIFF
--- a/src/request-storage-access.js
+++ b/src/request-storage-access.js
@@ -55,7 +55,6 @@
   let storageParams = {};
   let originalCCPUrl = '';
   let rsaContainer = null;
-  let onGrantCallbackInvoked = false;
   let requesthandlerUnsubscriber;
 
   const storageAccessEvents = {
@@ -263,6 +262,8 @@
     if (requesthandlerUnsubscriber) {
       requesthandlerUnsubscriber.unsubscribe();
     }
+
+    let onGrantCallbackInvoked = false;
 
     requesthandlerUnsubscriber = onRequestHandler({
       onInit: (messageData) => {


### PR DESCRIPTION
*Issue #809*

*Description of changes:*

This may fix #809 .

Since the changes in v2.6.2, any subsequent executions of `initCCP` after the first run do not trigger the `setupInitCCP` process. This PR fixes this issue.

The fix is straightforward: instead of executing `setupInitCCP` only once during the entire lifecycle of amazon-connect-streams, it is now executed every time `initCCP` is run. This ensures that the necessary setup processes are consistently performed on each initialization.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

