### PR TITLE
Update index.d.ts with correct return type for getMonitorCapabilities

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1976,14 +1976,14 @@ declare namespace connect {
     /** Returns true if agent's monitoringCapabilities contain MonitoringMode.BARGE state type. */
     isBargeEnabled(): boolean;
     
-    /** Returns the array of enabled monitor states of this connection. The array will consist of MonitoringMode enum values. */
-    getMonitorCapabilities(): MonitoringMode[];
+    /** Returns the array of enabled monitor states of this connection or undefined, if connection doesn't have enabled monitor states. The array will consist of MonitoringMode enum values. */
+    getMonitorCapabilities(): MonitoringMode[] | undefined;
     
     /**
     * Returns the current monitoring state of this connection.
     * This value can be one of MonitoringMode enum values if the agent is supervisor, otherwise the monitorStatus will be undefined for the agent.
     */
-    getMonitorStatus(): MonitoringMode;
+    getMonitorStatus(): MonitoringMode | null;
     
     /** Returns true if the connection was forced muted by the manager. */
     isForcedMute(): boolean;


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/amazon-connect/amazon-connect-streams/issues/800#issuecomment-1841192326

*Description of changes:*

Updating return type for getMonitorCapabilities and getMonitorStatus

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

