### PR TITLE
Cover different ccp versions in getConnectUrl

### DIFF
--- a/src/agent-app/agent-app.js
+++ b/src/agent-app/agent-app.js
@@ -33,7 +33,11 @@
   };
 
   var getConnectUrl = function (ccpUrl) {
-    var pos = ccpUrl.indexOf('ccp-v2');
+    var pos = ccpUrl.indexOf('ccp-v');
+    if (pos < 0) {
+      // see if this is v1 URL
+      pos = ccpUrl.indexOf('ccp#');
+    }
     return ccpUrl.slice(0, pos - 1);
   };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
My co-worker, Nicholai Main, discovered that `getConnectUrl` hardcoded ccp v2.
When ccp v1 is involved, the method fails to return valid URL.

This PR tries to cover multiple ccp versions in `getConnectUrl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

