### PR TITLE
feat: Update getLog().download() to support returning logs to caller

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -507,7 +507,7 @@
   };
   
   /**
-   * Download/Archive logs to a file, 
+   * Download/Archive logs to a file or fetch logs as a return of this function, 
    * By default, it returns all logs.
    * To filter logs by the minimum log level set by setLogLevel or the default set in _logLevel, 
    * pass in filterByLogLevel to true in options
@@ -516,16 +516,19 @@
    * - of type Object: 
    *   { logName: 'my-log-name',
    *     filterByLogLevel: false, //download all logs
+   *     returnLogsToCaller: true // true - return logs to call site, false - download logs to disk.
    *   }
    * - of type String (for backward compatibility), the file's name
    */
   Logger.prototype.download = function(options) {
     var logName = 'agent-log';
     var filterByLogLevel = false;
+    var returnLogsToCaller = false;
 
     if (typeof options === 'object') {
       logName = options.logName || logName;
       filterByLogLevel = options.filterByLogLevel || filterByLogLevel;
+      returnLogsToCaller = options.returnLogsToCaller || returnLogsToCaller;
     }
     else if (typeof options === 'string') {
       logName = options || logName;
@@ -537,6 +540,11 @@
       logs = logs.filter(function(entry) {
         return LogLevelOrder[entry.level] >= self._logLevel;
       });
+    }
+
+    if (returnLogsToCaller) {
+      /** Callsite requested for logs to be returned instead of downloading to disk **/
+      return logs;
     }
 
     var logBlob = new global.Blob([JSON.stringify(logs, undefined, 4)], ['text/plain']);


### PR DESCRIPTION
Update options for _getLog().download()_ to support a new property _returnLogsToCaller_ to obtain logs at callsite rather than downloading logs to disk.



*Description of changes:*

Hello connect team ! 

As of today, while debugging issues upon agent reports, they are required to download logs to disk first and then use a messaging platform like email/slack to send the agent log file. This has proven to be cumbersome and we are left with a massive trail of attachments sometimes on our issue tracking systems. I am opening this PR in hopes to access the logs directly from the callsite, with the plan being to refer the logs object and stream it back to an issue reporting service if you will. We want to use this as a means to build an automated issue reporting feature into our application and this would be helpful.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

