### PR TITLE
Return logBlob when download

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -565,6 +565,7 @@
     document.body.appendChild(downloadLink);
     downloadLink.click();
     document.body.removeChild(downloadLink);
+    return logBlob;
   };
 
   Logger.prototype.scheduleUpstreamLogPush = function (conduit) {


### PR DESCRIPTION
*Description of changes:*

For the sake of further logs processing (e.g. sending to backend) returning the blob from download function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

