### PR TITLE
Fix to add missing 'rejected' state to ConnectionStateType

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -2288,6 +2288,7 @@ An enumeration listing the different states that a connection can have.
 * `ConnectionStateType.CONNECTING`: The connection is being initialized.
 * `ConnectionStateType.CONNECTED`: The connection is connected to the contact.
 * `ConnectionStateType.HOLD`: The connection is connected but on hold.
+* `ConnectionStateType.REJECTED`: The connection is rejected.
 * `ConnectionStateType.DISCONNECTED`: The connection is no longer connected to the contact.
 * `ConnectionStateType.SILENT_MONITOR`: An enhanced listen-in manager session, this state is used instead of `ContactStateType.CONNECTED` for manager
 * `ContactStateType.BARGE`: A special manager session mode with full control over contact actions, this state is used instead of `ContactStateType.CONNECTED` for manager

--- a/src/api.js
+++ b/src/api.js
@@ -84,6 +84,7 @@
     'connecting',
     'connected',
     'hold',
+    'rejected',
     'disconnected',
     'silent_monitor',
     'barge'
@@ -94,6 +95,7 @@
     connect.ConnectionStateType.CONNECTING,
     connect.ConnectionStateType.CONNECTED,
     connect.ConnectionStateType.HOLD,
+    connect.ConnectionStateType.REJECTED,
     connect.ConnectionStateType.SILENT_MONITOR,
     connect.ConnectionStateType.BARGE
   ]);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -828,6 +828,9 @@ declare namespace connect {
     /** The connection is connected but on hold. */
     HOLD = "hold",
 
+    /** The connection is rejected. */
+    REJECTED = "rejected",
+
     /** The connection is no longer connected to the contact. */
     DISCONNECTED = "disconnected",
 


### PR DESCRIPTION
### Summary

This PR adds the missing `'rejected'` status to the `connect.ConnectionStateType` type definition.

### Context

While working on chat feature development, I came across [this issue](https://github.com/amazon-connect/amazon-connect-streams/issues/792#issuecomment-1887946425), which explained that chat sessions rejected by agents are represented using the `'rejected'` connection state.

However, `'REJECTED'` was not included in the `ConnectionStateType` TypeScript declarations, nor in the documented state list. This resulted in type mismatches when handling rejected chat sessions via `contact.getAgentConnection().getStatus().type`.

### Change Details

- Extended the `ConnectionStateType` union to include `'rejected'`.