### PR TITLE
Fix type for AgentAvailabilityState

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1480,6 +1480,10 @@ declare namespace connect {
     readonly state: string;
     /** Date indicating when the agent went into the current state. */
     readonly timeStamp: Date;
+    /** The agent state ARN. */
+    agentStateARN: string;
+    /** The agent state type. */
+    type: string;
   }
 
   /** An object containing the current Agent state. */


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/amazon-connect/amazon-connect-streams/issues/1011

*Description of changes:*
Correct the type definition of getAvailabilityState to reflect its real return value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

