### PR TITLE
Fix "publishTelemetryEvent is not defined" when bundled as ESM (strict mode)

### DIFF
--- a/src/softphone.js
+++ b/src/softphone.js
@@ -1130,7 +1130,7 @@
     }
   }
 
-  publishTelemetryEvent = function (eventName, contactId, data) {
+  var publishTelemetryEvent = function (eventName, contactId, data) {
     try {
       connect.publishMetric({
         name: eventName,


### PR DESCRIPTION
## Issue

Fixes #1102

## Problem

`amazon-connect-streams@2.26.0` cannot be loaded as an ES module. Importing it from a strict-mode bundler (Vite/esbuild, Rollup, …) throws at load time:

```
Uncaught ReferenceError: publishTelemetryEvent is not defined
    at connect-streams.js
    at 806 (connect-streams.js)
    at __webpack_require__ (connect-streams.js)
```

This aborts the webpack bootstrap, so the global `connect` is never set. It's a regression in 2.26.0 — 2.25.2 and earlier import cleanly.

## Root cause

In `src/softphone.js`, `publishTelemetryEvent` was assigned **without a declaration**:

```js
publishTelemetryEvent = function (eventName, contactId, data) { ... };
```

It's never declared with `var`/`let`/`const` anywhere in the file's IIFE, so it's an implicit global. That only works in sloppy mode (the prebuilt UMD is a non-strict IIFE). ES modules are always strict, where assigning to an undeclared name throws `ReferenceError`.

The equivalent helpers in `src/mediaControllers/chat.js` and `src/mediaControllers/task.js` are already declared with `var`.

## Fix

Declare it with `var`, matching the other media controllers. The assignment runs during IIFE execution before any of its call sites fire, so adding the (hoisted) declaration is behavior-preserving.

```diff
-  publishTelemetryEvent = function (eventName, contactId, data) {
+  var publishTelemetryEvent = function (eventName, contactId, data) {
```

## Notes

Source-only change, per the contributing guide (kept focused). The committed `release/` bundles still need to be regenerated from source by maintainers.
