### PR TITLE
Fix getActiveRegion() return type to string | undefined

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -390,7 +390,7 @@ declare namespace connect {
      * Get the active region for Global Resiliency, i.e. 'us-west-2'
      *
      */
-    getActiveRegion(): String;
+    getActiveRegion(): string | undefined;
 
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
'getActiveRegion()' was typed as returning `String` (the boxed object type) instead of 'string' (the primitive type). It can also return 'undefined' when Global Resiliency isn't enabled, which the original type signature didn't reflect at all.

Changed the declaration in `src/index.d.ts`:
```ts
getActiveRegion(): string | undefined;

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

